### PR TITLE
Use a generic representation for serial port name

### DIFF
--- a/TheiaMCR/TheiaMCR.py
+++ b/TheiaMCR/TheiaMCR.py
@@ -42,7 +42,7 @@ class MCRControl():
     iris = None
     
     # MCRInit
-    def __init__(self, com:str):
+    def __init__(self, serial_port:str):
         '''
         This class is used for interacting with the Theia MCR motor control boards. 
         Initialize the MCR board (this class) before any commands can be sent.  
@@ -74,9 +74,14 @@ class MCRControl():
         else:
             # initialize board
             try:
-                self.serialPort = serial.Serial(port = com, baudrate=115200, bytesize=8, timeout=0.1, stopbits=serial.STOPBITS_ONE)
-                success = int(com[3:])
-                log.debug(f'Comport {success} communication success')
+                self.serialPort = serial.Serial(
+                    port=serial_port,
+                    baudrate=115200,
+                    bytesize=8,
+                    timeout=0.1,
+                    stopbits=serial.STOPBITS_ONE,
+                )
+                log.debug(f"Serial communication opened on {serial_port} successfully")
             except serial.SerialException as e:
                 log.error("Serial port not open {}".format(e))
                 err.saveError(err.ERR_SERIAL_PORT, err.MOD_MCR, err.errLine())

--- a/TheiaMCR/TheiaMCR.py
+++ b/TheiaMCR/TheiaMCR.py
@@ -81,6 +81,7 @@ class MCRControl():
                     timeout=0.1,
                     stopbits=serial.STOPBITS_ONE,
                 )
+                success = 1
                 log.debug(f"Serial communication opened on {serial_port} successfully")
             except serial.SerialException as e:
                 log.error("Serial port not open {}".format(e))


### PR DESCRIPTION
The current implementation does not support UNIX style serial device names, i.e. `/dev/ttyAMA0`.
This behaviour is caused by the line which converts the `com` port name to an integer.
This PR removes the conflicting line, enabling support for any serial port naming scheme supported by the underlying `Serial` library.